### PR TITLE
CRAM support added w/samtools. Multithreaded computation is added for…

### DIFF
--- a/src/GenomeCopyNumber.h
+++ b/src/GenomeCopyNumber.h
@@ -118,8 +118,9 @@ public:
     void setBAFtrue();
     void setNormalContamination(float normalContamination) ;
     void setAllNormal ();
-    void setSamtools(std::string const& pathToSamtools);
+    void setSamtools(std::string const& pathToSamtools, std::string const& SambambaThreads_);
     void setSambamba(std::string const& pathToSambamba, std::string const& SambambaThreads_);
+    void setReference(std::string const& pathToReference);
     bool ifHasBAF();
     void setSex(std::string sex);
     void setSeekSubclones(bool seekSubclones);
@@ -162,6 +163,7 @@ private:
 	std::string sex_;
 	std::string pathToSamtools_;
 	std::string pathToSambamba_;
+	std::string pathToReference_;
 	std::string SambambaThreads_;
 };
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,6 +253,9 @@ int main(int argc, char *argv[])
 
     string pathToSambamba = (std::string)cf.Value("general","sambamba","");
     string SambambaThreads = "";
+
+    SambambaThreads = (std::string)cf.Value("general","maxThreads",""); /* initialize SambambaThreads using maxThreads -- calkan */
+
     if (pathToSambamba != "")    {
         SambambaThreads = (std::string)cf.Value("general","SambambaThreads","");
         if (SambambaThreads == "")       {
@@ -262,7 +265,7 @@ int main(int argc, char *argv[])
         }
     }
 
-	bool has_window = cf.hasValue("general","window");
+    bool has_window = cf.hasValue("general","window");
     int window = (int)cf.Value("general","window",NA);
     bool ifTargeted = cf.hasValue("target","captureRegions");
 
@@ -792,16 +795,18 @@ int main(int argc, char *argv[])
     }
 
 	GenomeCopyNumber sampleCopyNumber;
-	sampleCopyNumber.setSamtools(pathToSamtools);
+	sampleCopyNumber.setSamtools(pathToSamtools, SambambaThreads);
 	sampleCopyNumber.setSambamba(pathToSambamba, SambambaThreads);
+	sampleCopyNumber.setReference(fastaFile);
 	sampleCopyNumber.setWESanalysis(WESanalysis);
 	sampleCopyNumber.setmakingPileup(makingPileup);
 
     sampleCopyNumber.setIfLogged(logLogNorm);
 
 	GenomeCopyNumber controlCopyNumber;
-	controlCopyNumber.setSamtools(pathToSamtools);
+	controlCopyNumber.setSamtools(pathToSamtools, SambambaThreads);
 	controlCopyNumber.setSambamba(pathToSambamba, SambambaThreads);
+	controlCopyNumber.setReference(fastaFile);
 	controlCopyNumber.setWESanalysis(WESanalysis);
 	controlCopyNumber.setmakingPileup(makingPileup);
     controlCopyNumber.setIfLogged(logLogNorm);

--- a/src/myFunc.h
+++ b/src/myFunc.h
@@ -85,7 +85,7 @@ float get_iqr(const std::vector<float>& data);
 void readFileWithGenomeInfo(const std::string &chrLenFileName, std::vector<std::string>& names, std::vector<int>& lengths);
 void readChrNamesInBed(const std::string &targetBed, std::vector<std::string>&names_bed);
 unsigned long sum(const std::vector<int>& data);
-long getLineNumber(std::string const& file, const std::string& pathToSamtools, const std::string& pathToSambamba, const std::string& SambambaThreads);
+long getLineNumber(std::string const& file, std::string const& refFileName, const std::string& pathToSamtools, const std::string& pathToSambamba, const std::string& SambambaThreads);
 long getReadNumberFromPileup(std::string const& file);
 int factorial (int num);
 int get_max_index(const std::vector<float>& data);


### PR DESCRIPTION
Several changes:

1- CRAM support is added when samtools is used. Sambamba is disabled for CRAM, since sambamba uses a very old version of htslib that causes segmentation fault with CRAM files.
2- Sambambathreads now defaults to maxThreads even when samtools is used. The value is passed to samtools for multithreaded decompression (-@ maxThreads).
3- fastaFile in BAF options is used for the reference genome for CRAM decompression. 