### PR TITLE
Fix when fasta has more than one word in header

### DIFF
--- a/scripts/get_fasta_lengths.pl
+++ b/scripts/get_fasta_lengths.pl
@@ -21,17 +21,19 @@ open (FILE, "<$Filename") or die "Cannot open file!!!!: $!";
 open (OUT, ">$result_file") or die "Cannot open file!!!!: $!";
 
 $_ = <FILE>;
-if (/>(.*)/) {		
-	 print OUT $1,"\t";
+if (/>(.*)/) {
+	my @line_splits = split /\s+/, $1;	
+	print OUT $line_splits[0],"\t";
 }
 my $length = 0;
 
 while (<FILE>)  {
 	chomp;
-	if (/>(.*)/) {	
+	if (/>(.*)/) {
+		my @line_splits = split /\s+/, $1;	
 		print OUT $length,"\n";
 		$length = 0;
-		 print OUT $1,"\t";
+		print OUT $line_splits[0],"\t";
 	}
 	else {
 		$length += length($_);


### PR DESCRIPTION
Error when fasta file has more than one word, like ">chr_name description".
Then the result will be "name_chr description <some number>".
This will be a problem in freec when try to find the index "GenomeCopyNumber::findIndex".
miguel