### PR TITLE
Alternative FREEC usage from a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y gcc g++ make
+
+COPY src /app/src
+
+WORKDIR /app/src
+
+RUN rm -f /app/src/freec && make && chmod +x /app/src/freec
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+RUN groupadd --gid $GROUP_ID -r user && useradd -r --uid $USER_ID --gid $GROUP_ID user
+USER user
+
+ENTRYPOINT ["./freec", "-conf"]
+CMD ["/app/data/test/config_BL.txt"]

--- a/README.md
+++ b/README.md
@@ -21,7 +21,38 @@ Control-FREEC accepts .GZ files. Support of Eland, BED, SOAP, arachne, psl (BLAT
 
 ---------------------------------------------------------------------------------------------------------------------------
 
-**Installation:** To install FREEC, type "make" in the command line. If you are using Linux 32bit, please remove 64bit-tags from the Makefile file before building the program.
+**Installation:** 
+
+To install FREEC, type "make" in the command line. If you are using Linux 32bit, please remove 64bit-tags from the Makefile file before building the program.
+
+Alternatively, you may experiment with a FREEC executable from the **master** branch (w/o locally installed make, C++ compiler) by following the steps:
+1. [Install Docker](https://docs.docker.com/get-docker/).
+2. Get the `knotnote/control-freec:latest` docker image:
+   - if you are using Docker Desktop, follow [these instructions](https://docs.docker.com/desktop/dashboard/#pull-the-latest-image-from-docker-hub)
+   - or from the console: `docker pull knotnote/control-freec:latest`
+3. Get the config file that you plan to use. Add \'/app/data/\' prefix to all data paths.
+   
+   Example:
+
+         [general]
+         chrLenFile = hs18_chr.len
+
+   becomes:
+         
+         [general]
+         chrLenFile = /app/data/hs18_chr.len
+
+4. Run FREEC. Use the following command: 
+   
+   `docker run --rm -it -v path_to_data:/app/data knotnote/control-freec:latest path_to_config_file`
+
+   where:
+
+      - path_to_data - **absolute** path to the directory with input data **and** a configuration file.
+
+      - path_to_config_file - path to the config file, prefixed with '/app/data/'.
+
+If set up correctly, FREEC outputs will be in the `path_to_data/outputDir` folder, where *outputDir* is a parameter from the configuration file.
 
 ---------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The goal is to make FREEC experiments simpler, without the need to set up C++, make and miscellaneous libraries on the end-user's operating system.
Using [Docker](https://www.docker.com/) allows to developers to bake a container, ready for execution as a one-liner command.
Drawbacks:
- users have to install Docker (this is substantially easier than that listed above)
- need to keep track of folder locations: as per the README, users make a minor modification to a configuration file and have to use the instructions in the README carefully to get the results